### PR TITLE
Fix missing variable in sprintf() call

### DIFF
--- a/Event/OgoneEvent.php
+++ b/Event/OgoneEvent.php
@@ -34,8 +34,8 @@ class OgoneEvent extends Event
      */
     public function getParameter($name)
     {
-        if(!array_key_exists($name, $this->parameters)) {
-            throw new \InvalidArgumentException(sprintf('The parameter "%s" does not exist in Ogone response parameters'));
+        if (!array_key_exists($name, $this->parameters)) {
+            throw new \InvalidArgumentException(sprintf('The parameter "%s" does not exist in Ogone response parameters', $name));
         }
 
         return $this->parameters[$name];


### PR DESCRIPTION
I got this warning:

```
PHP Warning:  sprintf(): Too few arguments in .../vendor/snowcap/ogone-bundle/Snowcap/OgoneBundle/Event/OgoneEvent.php on line 38
```

and indeed the `$name` variable was missing in `sprintf()` call.
