### PR TITLE
Fix bundle parameters (start with bundle alias)

### DIFF
--- a/DependencyInjection/SnowcapOgoneExtension.php
+++ b/DependencyInjection/SnowcapOgoneExtension.php
@@ -33,8 +33,8 @@ class SnowcapOgoneExtension extends Extension
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.yml');
 
-        foreach (array('pspid','environment','sha_in','sha_out','options') as $attribute) {
-            $container->setParameter($attribute , $config[$attribute]);
+        foreach (array('pspid', 'environment', 'sha_in', 'sha_out', 'options') as $attribute) {
+            $container->setParameter('snowcap_ogone.' . $attribute , $config[$attribute]);
         }
     }
 }

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -1,16 +1,26 @@
 parameters:
-    pspid: ~
-    environment: ~
-    sha_in: ~
-    sha_out: ~
-    options: ~
+    snowcap_ogone.pspid: ~
+    snowcap_ogone.environment: ~
+    snowcap_ogone.sha_in: ~
+    snowcap_ogone.sha_out: ~
+    snowcap_ogone.options: ~
 
 services:
     snowcap_ogone:
         class: Snowcap\OgoneBundle\OgoneManager
-        arguments: [@event_dispatcher, @logger, @snowcap_ogone.form_generator, %pspid%, %environment%, %sha_in%, %sha_out%, %options%]
+        arguments:
+            - @event_dispatcher
+            - @logger
+            - @snowcap_ogone.form_generator
+            - %snowcap_ogone.pspid%
+            - %snowcap_ogone.environment%
+            - %snowcap_ogone.sha_in%
+            - %snowcap_ogone.sha_out%
+            - %snowcap_ogone.options%
 
     snowcap_ogone.form_generator:
         class: Snowcap\OgoneBundle\FormGenerator\SimpleFormGenerator
-        arguments: [@twig, %kernel.root_dir%]
+        arguments:
+            - @twig
+            - %kernel.root_dir%
         private: true


### PR DESCRIPTION
As stated in the docs (@see
http://symfony.com/doc/master/cookbook/bundles/best_practices.html#configuration):
"Each parameter name should start with the bundle alias, though this is
just a best-practice suggestion."
