### PR TITLE
[FIX] symfony 3 compatibility

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -8,9 +8,9 @@ parameters:
 services:
     snowcap_ogone:
         class: Snowcap\OgoneBundle\OgoneManager
-        arguments: [@event_dispatcher, @logger, @snowcap_ogone.form_generator, %pspid%, %environment%, %sha_in%, %sha_out%, %options%]
+        arguments: ['@event_dispatcher', '@logger', '@snowcap_ogone.form_generator', %pspid%, %environment%, %sha_in%, %sha_out%, %options%]
 
     snowcap_ogone.form_generator:
         class: Snowcap\OgoneBundle\FormGenerator\SimpleFormGenerator
-        arguments: [@twig, %kernel.root_dir%]
+        arguments: ['@twig', %kernel.root_dir%]
         private: true


### PR DESCRIPTION
The current bundle can not run with version 3 of Symfony due to services dependencies declaration.

This PR fixes the services declaration.
Referring to the UPGRADE Guide in the [yaml section](https://github.com/symfony/symfony/blob/master/UPGRADE-3.0.md#yaml) :

> Starting an unquoted string with @, `, |, or > leads to a ParseException.
